### PR TITLE
Refactor twin_id shouldn't be requested from the user in creation of farm or node

### DIFF
--- a/packages/registrar_client/lib/models/node.dart
+++ b/packages/registrar_client/lib/models/node.dart
@@ -214,9 +214,8 @@ class UptimeReport {
 }
 
 class NodeRegistrationRequest extends NodeBase {
-  final int twinID;
+  late final int twinID;
   NodeRegistrationRequest({
-    required this.twinID,
     required int farmID,
     required List<Interface> interfaces,
     required Location location,

--- a/packages/registrar_client/lib/src/accounts.dart
+++ b/packages/registrar_client/lib/src/accounts.dart
@@ -24,7 +24,9 @@ class Accounts {
     );
 
     final response = await _client.post(path: '$path/', body: body.toJson());
-    return Account.fromJson(response);
+    final account = Account.fromJson(response);
+    _client.twinId = account.twinID;
+    return account;
   }
 
   Future<Account> getByTwinID(int twinID) async {
@@ -39,11 +41,12 @@ class Accounts {
     return Account.fromJson(response);
   }
 
-  Future<dynamic> update(int twinID, AccountUpdateRequest body) async {
+  Future<dynamic> update(AccountUpdateRequest body) async {
+    final twinId = _client.twinId!;
     final header = await createAuthHeader(
-        twinID, _client.mnemonicOrSeed, _client.keypairType);
+        twinId, _client.mnemonicOrSeed, _client.keypairType);
     final response = await _client.patch(
-        path: '$path/$twinID', body: body.toJson(), headers: header);
+        path: '$path/$twinId', body: body.toJson(), headers: header);
     return response;
   }
 }

--- a/packages/registrar_client/lib/src/accounts.dart
+++ b/packages/registrar_client/lib/src/accounts.dart
@@ -42,6 +42,7 @@ class Accounts {
   }
 
   Future<dynamic> update(AccountUpdateRequest body) async {
+    _client.ensureTwinIdExists('updating an account');
     final twinId = _client.twinId!;
     final header = await createAuthHeader(
         twinId, _client.mnemonicOrSeed, _client.keypairType);

--- a/packages/registrar_client/lib/src/accounts.dart
+++ b/packages/registrar_client/lib/src/accounts.dart
@@ -23,7 +23,7 @@ class Accounts {
       rmbEncKey: rmbEncKey,
     );
 
-    final response = await _client.post(path: '$path/', body: body.toJson());
+    final response = await _client.post(path: '$path', body: body.toJson());
     final account = Account.fromJson(response);
     _client.twinId = account.twinID;
     return account;
@@ -31,13 +31,13 @@ class Accounts {
 
   Future<Account> getByTwinID(int twinID) async {
     final response =
-        await _client.get(path: '$path/', query: {'twin_id': twinID});
+        await _client.get(path: '$path', query: {'twin_id': twinID});
     return Account.fromJson(response);
   }
 
   Future<Account> getByPublicKey(String publicKey) async {
     final response =
-        await _client.get(path: '$path/', query: {'public_key': publicKey});
+        await _client.get(path: '$path', query: {'public_key': publicKey});
     return Account.fromJson(response);
   }
 

--- a/packages/registrar_client/lib/src/client.dart
+++ b/packages/registrar_client/lib/src/client.dart
@@ -14,6 +14,7 @@ class RegistrarClient {
   final String mnemonicOrSeed;
   final KPType keypairType;
 
+  late final int? twinId;
   late final Zos zos;
   late final Nodes nodes;
   late final Farms farms;
@@ -29,6 +30,19 @@ class RegistrarClient {
     nodes = Nodes(this);
     farms = Farms(this);
     accounts = Accounts(this);
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    final publicKey = await derivePublicKey(mnemonicOrSeed, keypairType);
+    try{
+      final account = await this.accounts.getByPublicKey(publicKey);
+      this.twinId = account.twinID;
+    } catch(e){
+       if (!e.toString().contains("404")){
+        throw e;
+       }
+    }
   }
 
   dynamic _handleResponse(http.Response response) {

--- a/packages/registrar_client/lib/src/client.dart
+++ b/packages/registrar_client/lib/src/client.dart
@@ -11,21 +11,28 @@ import 'accounts.dart';
 
 class RegistrarClient {
   final String baseUrl;
-  final String mnemonicOrSeed;
   final KPType keypairType;
 
-  late final int? twinId;
+  int? _twinId;
+  String _mnemonicOrSeed;
   late final Zos zos;
   late final Nodes nodes;
   late final Farms farms;
   late Accounts accounts;
+
+  int? get twinId => _twinId;
+  String get mnemonicOrSeed => _mnemonicOrSeed;
+
+  set twinId(int? value) {
+    _twinId = value;
+  }
 
   RegistrarClient({
     required String baseUrl,
     required String mnemonicOrSeed,
     this.keypairType = KPType.sr25519,
   })  : baseUrl = _validateBaseUrl(baseUrl),
-        mnemonicOrSeed = _validateSecret(mnemonicOrSeed) {
+        _mnemonicOrSeed = _validateSecret(mnemonicOrSeed) {
     zos = Zos(this);
     nodes = Nodes(this);
     farms = Farms(this);
@@ -34,10 +41,10 @@ class RegistrarClient {
   }
 
   Future<void> _initialize() async {
-    final publicKey = await derivePublicKey(mnemonicOrSeed, keypairType);
+    final publicKey = await derivePublicKey(_mnemonicOrSeed, keypairType);
     try{
       final account = await this.accounts.getByPublicKey(publicKey);
-      this.twinId = account.twinID;
+      this._twinId = account.twinID;
     } catch(e){
        if (!e.toString().contains("404")){
         throw e;
@@ -136,4 +143,13 @@ class RegistrarClient {
     }
     return mnemonicOrSeed;
   }
+
+  ensureTwinIdExists(String operation) {
+    final twinId = _twinId;
+    if (twinId == null) {
+      throw Exception(
+          'TwinId is not set. Please create an account before $operation.');
+    }
+  }
 }
+

--- a/packages/registrar_client/lib/src/client.dart
+++ b/packages/registrar_client/lib/src/client.dart
@@ -39,16 +39,16 @@ class RegistrarClient {
     accounts = Accounts(this);
     _initialize();
   }
-
   Future<void> _initialize() async {
     final publicKey = await derivePublicKey(_mnemonicOrSeed, keypairType);
-    try{
+    try {
       final account = await this.accounts.getByPublicKey(publicKey);
       this._twinId = account.twinID;
-    } catch(e){
-       if (!e.toString().contains("404")){
-        throw e;
-       }
+    } catch (e) {
+      if (!e.toString().contains("404")) {
+        throw Exception('Failed to initialize the client: $e');
+      }
+      print('Error: $e');
     }
   }
 
@@ -152,4 +152,3 @@ class RegistrarClient {
     }
   }
 }
-

--- a/packages/registrar_client/lib/src/farms.dart
+++ b/packages/registrar_client/lib/src/farms.dart
@@ -9,7 +9,8 @@ class Farms {
 
   Farms(this._client);
 
-  Future<int> create(String farmName, bool dedicated, String stellarAddress) async {
+  Future<int> create(
+      String farmName, bool dedicated, String stellarAddress) async {
     final twinId = _client.twinId!;
     final header = await createAuthHeader(
         twinId, _client.mnemonicOrSeed, _client.keypairType);
@@ -38,6 +39,7 @@ class Farms {
     if (farmName == null && stellarAddress == null) {
       return;
     }
+
     final twinId = _client.twinId!;
     final header = await createAuthHeader(
         twinId, _client.mnemonicOrSeed, _client.keypairType);

--- a/packages/registrar_client/lib/src/farms.dart
+++ b/packages/registrar_client/lib/src/farms.dart
@@ -9,15 +9,15 @@ class Farms {
 
   Farms(this._client);
 
-  Future<int> create(String farmName, bool dedicated, String stellarAddress,
-      int twinID) async {
+  Future<int> create(String farmName, bool dedicated, String stellarAddress) async {
+    final twinId = _client.twinId!;
     final header = await createAuthHeader(
-        twinID, _client.mnemonicOrSeed, _client.keypairType);
+        twinId, _client.mnemonicOrSeed, _client.keypairType);
     final farm = Farm(
         dedicated: dedicated,
         farmName: farmName,
         stellarAddress: stellarAddress,
-        twinID: twinID);
+        twinID: twinId);
     final response = await _client.post(
         path: '$path/', body: farm.toJson(), headers: header);
     return response['farm_id'];
@@ -33,13 +33,14 @@ class Farms {
     return List<Farm>.from(response.map((farm) => Farm.fromJson(farm)));
   }
 
-  Future<dynamic> update(int twinID, int farmID,
+  Future<dynamic> update(int farmID,
       {String? farmName, String? stellarAddress}) async {
     if (farmName == null && stellarAddress == null) {
       return;
     }
+    final twinId = _client.twinId!;
     final header = await createAuthHeader(
-        twinID, _client.mnemonicOrSeed, _client.keypairType);
+        twinId, _client.mnemonicOrSeed, _client.keypairType);
     final body = {
       if (farmName != null) 'farm_name': farmName,
       if (stellarAddress != null) 'stellar_address': stellarAddress

--- a/packages/registrar_client/lib/src/farms.dart
+++ b/packages/registrar_client/lib/src/farms.dart
@@ -8,9 +8,9 @@ class Farms {
   final String path = '/farms';
 
   Farms(this._client);
-
   Future<int> create(
       String farmName, bool dedicated, String stellarAddress) async {
+    _client.ensureTwinIdExists('creating a farm');
     final twinId = _client.twinId!;
     final header = await createAuthHeader(
         twinId, _client.mnemonicOrSeed, _client.keypairType);
@@ -33,13 +33,13 @@ class Farms {
     final response = await _client.get(path: '$path/', query: filter.toJson());
     return List<Farm>.from(response.map((farm) => Farm.fromJson(farm)));
   }
-
   Future<dynamic> update(int farmID,
       {String? farmName, String? stellarAddress}) async {
     if (farmName == null && stellarAddress == null) {
       return;
     }
 
+    _client.ensureTwinIdExists('updating a farm');
     final twinId = _client.twinId!;
     final header = await createAuthHeader(
         twinId, _client.mnemonicOrSeed, _client.keypairType);

--- a/packages/registrar_client/lib/src/farms.dart
+++ b/packages/registrar_client/lib/src/farms.dart
@@ -20,7 +20,7 @@ class Farms {
         stellarAddress: stellarAddress,
         twinID: twinId);
     final response = await _client.post(
-        path: '$path/', body: farm.toJson(), headers: header);
+        path: '$path', body: farm.toJson(), headers: header);
     return response['farm_id'];
   }
 
@@ -30,7 +30,7 @@ class Farms {
   }
 
   Future<List<Farm>> list(FarmFilter filter) async {
-    final response = await _client.get(path: '$path/', query: filter.toJson());
+    final response = await _client.get(path: '$path', query: filter.toJson());
     return List<Farm>.from(response.map((farm) => Farm.fromJson(farm)));
   }
   Future<dynamic> update(int farmID,

--- a/packages/registrar_client/lib/src/nodes.dart
+++ b/packages/registrar_client/lib/src/nodes.dart
@@ -10,6 +10,7 @@ class Nodes {
   Nodes(this._client);
 
   Future<int> create(NodeRegistrationRequest node) async {
+    node.twinID = _client.twinId!;
     final header = await createAuthHeader(
         node.twinID, _client.mnemonicOrSeed, _client.keypairType);
     final response = await _client.post(
@@ -27,18 +28,19 @@ class Nodes {
     return List<Node>.from(response.map((node) => Node.fromJson(node)));
   }
 
-  Future<dynamic> update(int twinID, int nodeID, UpdateNodeRequest node) async {
+  Future<dynamic> update(int nodeID, UpdateNodeRequest node) async {
+    final twinId = _client.twinId!;
     final header = await createAuthHeader(
-        twinID, _client.mnemonicOrSeed, _client.keypairType);
+        twinId, _client.mnemonicOrSeed, _client.keypairType);
     final response = await _client.patch(
         path: '$path/$nodeID', body: node.toJson(), headers: header);
     return response;
   }
 
-  Future<dynamic> reportNodeUptime(
-      int twinID, int nodeID, ReportUptimeRequest uptime) async {
+  Future<dynamic> reportNodeUptime(int nodeID, ReportUptimeRequest uptime) async {
+    final twinId = _client.twinId!;
     final header = await createAuthHeader(
-        twinID, _client.mnemonicOrSeed, _client.keypairType);
+        twinId, _client.mnemonicOrSeed, _client.keypairType);
     final response = await _client.post(
         path: '$path/$nodeID/uptime', body: uptime.toJson(), headers: header);
     return response;

--- a/packages/registrar_client/lib/src/nodes.dart
+++ b/packages/registrar_client/lib/src/nodes.dart
@@ -10,6 +10,7 @@ class Nodes {
   Nodes(this._client);
 
   Future<int> create(NodeRegistrationRequest node) async {
+    _client.ensureTwinIdExists('creating a node');
     node.twinID = _client.twinId!;
     final header = await createAuthHeader(
         node.twinID, _client.mnemonicOrSeed, _client.keypairType);
@@ -29,6 +30,7 @@ class Nodes {
   }
 
   Future<dynamic> update(int nodeID, UpdateNodeRequest node) async {
+    _client.ensureTwinIdExists('updating a node');
     final twinId = _client.twinId!;
     final header = await createAuthHeader(
         twinId, _client.mnemonicOrSeed, _client.keypairType);
@@ -38,6 +40,7 @@ class Nodes {
   }
 
   Future<dynamic> reportNodeUptime(int nodeID, ReportUptimeRequest uptime) async {
+    _client.ensureTwinIdExists('reporting node uptime');
     final twinId = _client.twinId!;
     final header = await createAuthHeader(
         twinId, _client.mnemonicOrSeed, _client.keypairType);

--- a/packages/registrar_client/lib/src/nodes.dart
+++ b/packages/registrar_client/lib/src/nodes.dart
@@ -15,7 +15,7 @@ class Nodes {
     final header = await createAuthHeader(
         node.twinID, _client.mnemonicOrSeed, _client.keypairType);
     final response = await _client.post(
-        path: '$path/', body: node.toJson(), headers: header);
+        path: '$path', body: node.toJson(), headers: header);
     return response['node_id'];
   }
 

--- a/packages/registrar_client/test/accounts_test.dart
+++ b/packages/registrar_client/test/accounts_test.dart
@@ -6,12 +6,10 @@ import 'package:registrar_client/registrar_client.dart';
 
 void main() {
   group('Test Account', () {
-    int twinID = 0;
-
     final mnemonic = generateMnemonic();
 
     final client = RegistrarClient(
-        baseUrl: 'http://registrar/v1', mnemonicOrSeed: mnemonic);
+        baseUrl: 'https://registrar.dev4.grid.tf/v1', mnemonicOrSeed: mnemonic);
 
     test('Create Account', () async {
       final account = await client.accounts.create();
@@ -19,22 +17,20 @@ void main() {
       expect(account, isNotNull);
       expect(account, isA<Account>());
       expect(account.twinID, isNotNull);
-
-      twinID = account.twinID;
     });
 
     test('Get Account by TwinID', () async {
-      final account = await client.accounts.getByTwinID(twinID);
+      final account = await client.accounts.getByTwinID(client.twinId!);
 
       expect(account, isNotNull);
-      expect(account.twinID, twinID);
+      expect(account.twinID, client.twinId!);
     });
 
     test('Get Account by PublicKey', () async {
       final account = await client.accounts
           .getByPublicKey(await derivePublicKey(mnemonic, KPType.sr25519));
       expect(account, isNotNull);
-      expect(account.twinID, twinID);
+      expect(account.twinID, client.twinId!);
     });
 
     test('Update Account', () async {
@@ -43,10 +39,10 @@ void main() {
         rmbEncKey: 'rmbEncKey',
       );
 
-      final response = await client.accounts.update(twinID, body);
+      final response = await client.accounts.update(body);
       expect(response, isNotNull);
 
-      final account = await client.accounts.getByTwinID(twinID);
+      final account = await client.accounts.getByTwinID(client.twinId!);
       expect(account, isNotNull);
       expect(account.relays, body.relays);
       expect(account.rmbEncKey, body.rmbEncKey);

--- a/packages/registrar_client/test/farms_test.dart
+++ b/packages/registrar_client/test/farms_test.dart
@@ -5,17 +5,15 @@ import 'package:registrar_client/registrar_client.dart';
 void main() {
   group('Test Farm', () {
     int farmID = 0;
-    int twinID = 0;
     final client = RegistrarClient(
-        baseUrl: 'http://registrar/v1', mnemonicOrSeed: generateMnemonic());
+        baseUrl: 'https://registrar.dev4.grid.tf/v1', mnemonicOrSeed: generateMnemonic());
     test('Create Farm', () async {
-      final account = await client.accounts.create();
-      twinID = account.twinID;
-      final farmName = '${DateTime.now()} - farm';
+      await client.accounts.create();
+      final farmName = '${DateTime.now().millisecondsSinceEpoch ~/ 1000}farm';
       final stellarAddress =
           "GC6CG2ME7UCJ56CEQ223QWWZ6N3UGTSXVNRJGDTE2DXUO4NQBLXZRWU5";
       final farmIDCreated =
-          await client.farms.create(farmName, true, stellarAddress, twinID);
+          await client.farms.create(farmName, true, stellarAddress);
       expect(farmID, isNotNull);
       expect(farmID, isA<int>());
       farmID = farmIDCreated;
@@ -28,7 +26,7 @@ void main() {
     });
 
     test('List Farm with twinID', () async {
-      final filter = FarmFilter(twinID: twinID);
+      final filter = FarmFilter(twinID: client.twinId!);
       final farms = await client.farms.list(filter);
       expect(farms, isNotNull);
       expect(farms, isA<List<Farm>>());
@@ -43,9 +41,9 @@ void main() {
     });
 
     test('Update Farm', () async {
-      final farmName = '${DateTime.now()} - farm';
+      final farmName = '${DateTime.now()}farm';
       final response =
-          await client.farms.update(twinID, farmID, farmName: farmName);
+          await client.farms.update(farmID , farmName: farmName, stellarAddress: 'GC6CG2ME7UCJ56CEQ223QWWZ6N3UGTSXVNRJGDTE2DXUO4NQBLXZRWU5');
       expect(response, isNotNull);
 
       final farm = await client.farms.get(farmID);

--- a/packages/registrar_client/test/nodes_test.dart
+++ b/packages/registrar_client/test/nodes_test.dart
@@ -6,24 +6,21 @@ void main() async {
   group('Test Nodes', () {
     final mnemonic = generateMnemonic();
     final client = RegistrarClient(
-        baseUrl: 'http://registrar/v1', mnemonicOrSeed: mnemonic);
-    int twinID = 0;
+        baseUrl: 'https://registrar.dev4.grid.tf/v1', mnemonicOrSeed: mnemonic);
     int farmID = 0;
     int nodeID = 0;
     test('Register node', () async {
-      final account = await client.accounts.create();
-      twinID = account.twinID;
+      await client.accounts.create();
       final stellarAddress =
           "GC6CG2ME7UCJ56CEQ223QWWZ6N3UGTSXVNRJGDTE2DXUO4NQBLXZRWU5";
-      final farmName = '${DateTime.now()} - farm';
+      final farmName = '${DateTime.now().millisecondsSinceEpoch ~/ 1000}farm';
       final farmIDCreated =
-          await client.farms.create(farmName, true, stellarAddress, twinID);
+          await client.farms.create(farmName, true, stellarAddress);
       expect(farmID, isNotNull);
       expect(farmID, isA<int>());
       farmID = farmIDCreated;
 
       final node = NodeRegistrationRequest(
-        twinID: twinID,
         farmID: farmID,
         interfaces: [
           Interface(
@@ -67,7 +64,7 @@ void main() async {
     });
 
     test('List nodes', () async {
-      final nodes = await client.nodes.list(NodeFilter(twinID: twinID));
+      final nodes = await client.nodes.list(NodeFilter(twinID: client.twinId!));
       expect(nodes, isNotNull);
       expect(nodes, isA<List<Node>>());
       expect(nodes.length, greaterThan(0));
@@ -99,7 +96,7 @@ void main() async {
         virtualized: true,
       );
 
-      final updatedNode = await client.nodes.update(twinID, nodeID, node);
+      final updatedNode = await client.nodes.update(nodeID, node);
       expect(updatedNode, isNotNull);
 
       final nodeUpdated = await client.nodes.get(nodeID);
@@ -115,7 +112,7 @@ void main() async {
       );
 
       final response =
-          await client.nodes.reportNodeUptime(twinID, nodeID, uptime);
+          await client.nodes.reportNodeUptime(nodeID, uptime);
       expect(response, isNotNull);
 
       final node = await client.nodes.get(nodeID);


### PR DESCRIPTION
## Changes:
- store twin id on creating registrar client by querying it
- store twin id on creating account 
- use stored twin id in creating and updating of farm or node

## Related issues:
#10 