### PR TITLE
Update pubspec git dep after repo rename (tfgrid-sdk-dart->zos_sdk_dart)

### DIFF
--- a/packages/registrar_client/pubspec.yaml
+++ b/packages/registrar_client/pubspec.yaml
@@ -11,7 +11,7 @@ resolution: workspace
 dependencies:
   signer:
     git:
-      url: https://github.com/threefoldtech/tfgrid-sdk-dart
+      url: https://github.com/threefoldtech/zos_sdk_dart
       ref: development
       path: packages/signer
   http: ^1.3.0


### PR DESCRIPTION
`packages/registrar_client/pubspec.yaml` pulls `signer` via `git:` from `threefoldtech/tfgrid-sdk-dart` (renamed to `zos_sdk_dart`). Points the dependency URL at the new name instead of relying on GitHub's non-permanent rename redirect. Verified `packages/signer` exists on `zos_sdk_dart@development` (200). No functional change.

Part of the repo-rename migration off GitHub redirects.